### PR TITLE
Fix incorrect constructor usage in PhotoBot.java (Lesson 2)

### DIFF
--- a/java-telegram-bot-tutorial/Lesson2/src/PhotoBot.java
+++ b/java-telegram-bot-tutorial/Lesson2/src/PhotoBot.java
@@ -95,7 +95,7 @@ public class PhotoBot implements LongPollingSingleThreadUpdateConsumer {
                         .builder()
                         .chatId(chat_id)
                         .text("Keyboard hidden")
-                        .replyMarkup(new ReplyKeyboardRemove())
+                        .replyMarkup(ReplyKeyboardRemove.builder().build())
                         .build();
                 try {
                     telegramClient.execute(message); // Call method to send the photo


### PR DESCRIPTION
In java-telegram-bot-tutorial/Lesson2/src/PhotoBot.java, the line 98:

`message.setReplyMarkup(new ReplyKeyboardRemove());  `

produces a compilation error because ReplyKeyboardRemove no longer has a default constructor.

This has been fixed by replacing it with:

`message.setReplyMarkup(ReplyKeyboardRemove.builder().build()); `
 
This update aligns the tutorial code with the current TelegramBots API usage (TelegramBots API version 9.0.0) .